### PR TITLE
fixes for ansible local-only iptables, httpd port, index.php

### DIFF
--- a/conf-mgmt/ansible/local-only/lamp_simple/group_vars/all
+++ b/conf-mgmt/ansible/local-only/lamp_simple/group_vars/all
@@ -1,6 +1,6 @@
 ---
 # Variables listed here are applicable to all host groups
 
-httpd_port: 8000
+httpd_port: 80
 ntpserver: localhost
 repository: https://github.com/bennojoy/mywebapp.git

--- a/conf-mgmt/ansible/local-only/lamp_simple/roles/common/tasks/main.yml
+++ b/conf-mgmt/ansible/local-only/lamp_simple/roles/common/tasks/main.yml
@@ -13,3 +13,12 @@
 - name: Start the ntp service
   service: name=ntpd state=started enabled=true
   tags: ntp
+
+- name: Check if /etc/sysconfig/iptables exists
+  stat: path=/etc/sysconfig/iptables
+  register: ipt
+
+- name: Place basic iptables rules
+  template: src=iptables.j2 dest=/etc/sysconfig/iptables
+  notify: restart iptables
+  when: ipt is defined and ipt.stat.exists == false

--- a/conf-mgmt/ansible/local-only/lamp_simple/roles/common/templates/iptables.j2
+++ b/conf-mgmt/ansible/local-only/lamp_simple/roles/common/templates/iptables.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+
+#Syn-flood protection
+-A INPUT -p tcp ! --syn -m state --state NEW -j DROP
+
+#Force SYN packets check
+-A INPUT -f -j DROP
+
+#Force Fragments packets check
+-A INPUT -p tcp --tcp-flags ALL ALL -j DROP
+
+#XMAS packets
+-A INPUT -p tcp --tcp-flags ALL NONE -j DROP
+
+# Accept packets belonging to established and related connections
+-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow pings
+-A INPUT -p icmp --icmp-type any -j ACCEPT
+
+# Set access for localhost
+-A INPUT -i lo -j ACCEPT
+
+# Allow SSH connections on tcp port 22
+-A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT
+
+# Set default policies for INPUT, FORWARD and OUTPUT chains
+-P INPUT DROP 
+-P FORWARD DROP
+-P OUTPUT ACCEPT
+
+COMMIT

--- a/conf-mgmt/ansible/local-only/lamp_simple/roles/web/templates/index.php.j2
+++ b/conf-mgmt/ansible/local-only/lamp_simple/roles/web/templates/index.php.j2
@@ -10,14 +10,14 @@
  Print "Hello, World! I am a web server configured using Ansible and I am : ";
  echo exec('hostname');
  Print  "</BR>";
-echo  "List of Databases: </BR>";
-        {% for host in groups['dbservers'] %}
-                $link = mysql_connect('{{ hostvars[host].ansible_eth0.ipv4.address }}', '{{ hostvars[host].dbuser }}', '{{ hostvars[host].upassword }}') or die(mysql_error());
-        {% endfor %}
-        $res = mysql_query("SHOW DATABASES");
-        while ($row = mysql_fetch_assoc($res)) {
-                echo $row['Database'] . "\n";
-        }
+ echo  "List of Databases: </BR>";
+ {% for host in groups['dbservers'] %}
+    $link = mysql_connect('{{ hostvars[host].ansible_eth0.ipv4.address }}', '{{ hostvars[host].dbuser }}', '{{ hostvars[host].upassword }}') or die(mysql_error());
+ {% endfor %}
+    $res = mysql_query("SHOW DATABASES");
+    while ($row = mysql_fetch_assoc($res)) {
+        echo $row['Database'] . "\n";
+    }
 ?>
 </body>
 </html>

--- a/conf-mgmt/ansible/local-only/verify_service.sh
+++ b/conf-mgmt/ansible/local-only/verify_service.sh
@@ -4,4 +4,4 @@
 # our deploy_hooks directory.
 . $(dirname $0)/common_variables.sh
 
-curl -s http://localhost:8000/ansible/index.php
+curl -s http://localhost:80/ansible/index.php


### PR DESCRIPTION
- check if /etc/sysconfig/iptables exists, if not place default template so that inlinefile does not fail in other roles
- change httpd back to port 80 since apache config was not changed to support 8000
- fix rendering issue on index.php
