### PR TITLE
Fix stop_server isExistApp variable

### DIFF
--- a/applications/SampleApp_Linux/scripts/stop_server
+++ b/applications/SampleApp_Linux/scripts/stop_server
@@ -1,5 +1,5 @@
 #!/bin/bash
-isExistApp = `pgrep httpd`
+isExistApp=`pgrep httpd`
 if [[ -n  $isExistApp ]]; then
     service httpd stop        
 fi


### PR DESCRIPTION
bash variable declaration and assignment must not contain spaces around '='
