### PR TITLE
Add support to check instance status Pending:Wait

### DIFF
--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -160,6 +160,12 @@ autoscaling_exit_standby() {
         return 0
     fi
 
+    if [ "$instance_state" == "Pending:Wait" ]; then
+        msg "Instance is Pending:Wait; nothing to do."
+        return 0
+    fi
+
+
     msg "Moving instance $instance_id out of Standby"
     $AWS_CLI autoscaling exit-standby \
         --instance-ids $instance_id \

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -155,7 +155,7 @@ autoscaling_exit_standby() {
         return 1
     fi
 
-    if [ "$instance_state" == "InService" ]; then
+    if [ "$instance_state" == "InService" || "$instance_state" == "Pending:Wait" ]; then
         msg "Instance is already InService; nothing to do."
         return 0
     fi

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -155,7 +155,7 @@ autoscaling_exit_standby() {
         return 1
     fi
 
-    if [ "$instance_state" == "InService" || "$instance_state" == "Pending:Wait" ]; then
+    if [ "$instance_state" == "InService" ]; then
         msg "Instance is already InService; nothing to do."
         return 0
     fi


### PR DESCRIPTION
When an autoscaling group creates a new instance that contains a loadblancer, if you try to run the script register_with_elb, it fails because the instance can't be moved to InService because has not end the autoscaling LifeCycle