### PR TITLE
Improved common-functions.sh

### DIFF
--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -199,7 +199,7 @@ autoscaling_exit_standby() {
     # where downscaling/scale-in policies will terminate an instance after executing CodeDeploy
     if [ -z "$min_cap" -o -z "$desired_cap" ]; then
         msg "Unable to determine minimum and desired capacity for ASG $asg_name."
-    elif [ $min_cap == $(($desired_cap-1)) -a $min_cap -gt 0 ]; then
+    elif [ $min_cap == $(($desired_cap-1)) ]; then
         local new_min=$(($min_cap + 1))
         msg "Incrementing ASG $asg_name's minimum size to $new_min"
         msg $($AWS_CLI autoscaling update-auto-scaling-group \

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -16,6 +16,9 @@
 # ELB_LIST defines which Elastic Load Balancers this instance should be part of.
 ELB_LIST=""
 
+# Flag for determining if the auto scaling group min was decremented at any point during execution
+ASGMINDECREMENTED="FALSE"
+
 # Under normal circumstances, you shouldn't need to change anything below this line.
 # -----------------------------------------------------------------------------
 
@@ -121,6 +124,8 @@ autoscaling_enter_standby() {
         if [ $? != 0 ]; then
             msg "Failed to reduce ASG $asg_name's minimum size to $new_min. Cannot put this instance into Standby."
             return 1
+        else
+            ASGMINDECREMENTED="TRUE"
         fi
     fi
 
@@ -187,28 +192,30 @@ autoscaling_exit_standby() {
         return 1
     fi
     
-    local min_desired=$($AWS_CLI autoscaling describe-auto-scaling-groups \
-        --auto-scaling-group-name $asg_name \
-        --query 'AutoScalingGroups[0].[MinSize, DesiredCapacity]' \
-        --output text)
-
-    local min_cap=$(echo $min_desired | awk '{print $1}')
-    local desired_cap=$(echo $min_desired | awk '{print $2}')
-
-    # Increment the ASG minimum size back to it's original value; this resolves issues
-    # where downscaling/scale-in policies will terminate an instance after executing CodeDeploy
-    if [ -z "$min_cap" -o -z "$desired_cap" ]; then
-        msg "Unable to determine minimum and desired capacity for ASG $asg_name."
-    elif [ $min_cap == $(($desired_cap-1)) ]; then
-        local new_min=$(($min_cap + 1))
-        msg "Incrementing ASG $asg_name's minimum size to $new_min"
-        msg $($AWS_CLI autoscaling update-auto-scaling-group \
+    if [ $ASGMINDECREMENTED == "TRUE" ]; then
+        local min_desired=$($AWS_CLI autoscaling describe-auto-scaling-groups \
             --auto-scaling-group-name $asg_name \
-            --min-size $new_min)
-        if [ $? != 0 ]; then
-            msg "Failed to increase ASG $asg_name's minimum size to $new_min."
-            return 1
+            --query 'AutoScalingGroups[0].[MinSize, DesiredCapacity]' \
+            --output text)
+
+        local min_cap=$(echo $min_desired | awk '{print $1}')
+        local desired_cap=$(echo $min_desired | awk '{print $2}')
+
+        if [ -z "$min_cap" -o -z "$desired_cap" ]; then
+            msg "Unable to determine minimum and desired capacity for ASG $asg_name."
+        elif [ $min_cap == $(($desired_cap-1)) ]; then
+            local new_min=$(($min_cap + 1))
+            msg "Incrementing ASG $asg_name's minimum size to $new_min"
+            msg $($AWS_CLI autoscaling update-auto-scaling-group \
+                --auto-scaling-group-name $asg_name \
+                --min-size $new_min)
+            if [ $? != 0 ]; then
+                msg "Failed to increase ASG $asg_name's minimum size to $new_min."
+                return 1
+            fi
         fi
+    else
+        msg "Auto scaling group was not decremented previously, not incrementing min value"
     fi
 
     return 0


### PR DESCRIPTION
Previously, executing these scripts against an auto scaling group would leave the ASG min value decremented by 1. This can potentially cause issues if the ASG has a downscaling/scale-in policy attached as it will terminate an instance (desired instances will be N, ASG min will be N-1, so scaledown policies will terminate one instance).