### PR TITLE
Use AWS installer for installing CodeDeploy agent

### DIFF
--- a/conf-mgmt/chef/aws-codedeploy-agent/cookbooks/codedeploy-agent/recipes/default.rb
+++ b/conf-mgmt/chef/aws-codedeploy-agent/cookbooks/codedeploy-agent/recipes/default.rb
@@ -1,10 +1,12 @@
-remote_file "#{Chef::Config[:file_cache_path]}/codedeploy-agent.rpm" do
-    source "https://s3.amazonaws.com/aws-codedeploy-us-east-1/latest/codedeploy-agent.noarch.rpm"
+remote_file "#{Chef::Config[:file_cache_path]}/codedeploy-agent-install" do
+    source "https://s3.amazonaws.com/aws-codedeploy-us-east-1/latest/install"
+    mode 0755
 end
 
-package "codedeploy-agent" do
-	action :install
-	source "#{Chef::Config[:file_cache_path]}/codedeploy-agent.rpm"
+bash "install-codedeploy-agent" do
+  code <<-EOH
+    #{Chef::Config[:file_cache_path]}/codedeploy-agent-install auto
+  EOH
 end
 
 service "codedeploy-agent" do


### PR DESCRIPTION
Amazon support has informed me that the install version is not the same as the RPM used by this cookbook, despite the resulting yum package version being identical.

Their recommendation is always to use the installer to setup the agent.