### PR TITLE
Do not continuously reinstall CodeDeploy agent on every Chef run.

### DIFF
--- a/conf-mgmt/chef/aws-codedeploy-agent/cookbooks/codedeploy-agent/recipes/default.rb
+++ b/conf-mgmt/chef/aws-codedeploy-agent/cookbooks/codedeploy-agent/recipes/default.rb
@@ -1,14 +1,16 @@
 remote_file "#{Chef::Config[:file_cache_path]}/codedeploy-agent-install" do
-    source "https://s3.amazonaws.com/aws-codedeploy-us-east-1/latest/install"
-    mode 0755
+  source "https://s3.amazonaws.com/aws-codedeploy-us-east-1/latest/install"
+  mode 0755
+  notifies :run, "bash[install-codedeploy-agent]", :immediately
 end
 
 bash "install-codedeploy-agent" do
   code <<-EOH
     #{Chef::Config[:file_cache_path]}/codedeploy-agent-install auto
   EOH
+  action :nothing
 end
 
 service "codedeploy-agent" do
-	action [:enable, :start]
+  action [:enable, :start]
 end


### PR DESCRIPTION
Admittedly, there might be better ways to handle this, but for now, this is a quick and easy way to ensure the install doesn't run on every single execution of Chef where this recipe is part of the run list.

We're experiencing random failures on the install part if CD is already installed, so hopefully this resolves the issue.