### PR TITLE
Suspend AZRebalance

### DIFF
--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -29,6 +29,8 @@ in the CLI's user guide.
     autoscaling:EnterStandby
     autoscaling:ExitStandby
     autoscaling:UpdateAutoScalingGroup
+    autoscaling:SuspendProcesses
+    autoscaling:ResumeProcesses
 ```
 
 Note: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -116,7 +116,8 @@ autoscaling_enter_standby() {
             --auto-scaling-group-name "${asg_name}" \
             --scaling-processes AZRebalance
         if [ $? != 0 ]; then
-            msg "Failed to suspend the AZRebalance process for ASG ${asg_name}, but continuing regardless. This may cause issues."
+            msg "Failed to suspend the AZRebalance process for ASG ${asg_name}. Aborting as this may cause issues."
+            return 1
         fi
     fi
 
@@ -246,7 +247,8 @@ autoscaling_exit_standby() {
             --auto-scaling-group-name "${asg_name}" \
             --scaling-processes AZRebalance
         if [ $? != 0 ]; then
-            msg "Failed to resume the AZRebalance process for ASG ${asg_name}, but continuing regardless. This may cause issues."
+            msg "Failed to resume the AZRebalance process for ASG ${asg_name}. This may cause issues!"
+            return 1
         fi
     fi
 


### PR DESCRIPTION
This commit adds the ability to suspend the ASG process AZRebalance before putting the instance in StandBy.

This is to cope with (the edge case) scenarios where the amount of subnets and desired instances forces the ASG to rebalance the instances during the deployment.

If the AutoScaling process was suspended beforhand then it's a noop.