### PR TITLE
automatically set ELB_LIST if not provided

### DIFF
--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -46,7 +46,5 @@ To use these scripts in your own application:
 1. Copy the `.sh` files in this directory into your application source.
 1. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
 and `register_with_elb.sh` on the ApplicationStart event.
-1. Edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load
-Balancer(s) your deployment group is a part of. Make sure the entries in ELB_LIST are separated by space.
 1. Deploy!
 

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -14,7 +14,7 @@
 # permissions and limitations under the License.
 
 # ELB_LIST defines which Elastic Load Balancers this instance should be part of.
-# The elements in ELB_LIST should be seperated by space.
+# The elements in ELB_LIST should be separated by space.
 ELB_LIST=""
 
 # Under normal circumstances, you shouldn't need to change anything below this line.

--- a/load-balancing/elb/deregister_from_elb.sh
+++ b/load-balancing/elb/deregister_from_elb.sh
@@ -52,7 +52,12 @@ msg "Instance is not part of an ASG, continuing..."
 
 msg "Checking that user set at least one load balancer"
 if test -z "$ELB_LIST"; then
-    error_exit "Must have at least one load balancer to deregister from"
+    msg "Finding all the ELBs that this instance is registered to"
+    get_elb_list $INSTANCE_ID
+    if [ $? != 0 ]; then
+        error_exit "Must have at least one load balancer to deregister from"
+    fi
+    echo "$ELB_LIST" > /tmp/elblist
 fi
 
 # Loop through all LBs the user set, and attempt to deregister this instance from them.

--- a/load-balancing/elb/register_with_elb.sh
+++ b/load-balancing/elb/register_with_elb.sh
@@ -52,7 +52,13 @@ msg "Instance is not part of an ASG, continuing..."
 
 msg "Checking that user set at least one load balancer"
 if test -z "$ELB_LIST"; then
-    error_exit "Must have at least one load balancer to register to"
+    if [ -a /tmp/elblist ]; then
+        msg "Finding all the ELBs that this instance was previously registered to"
+        read ELB_LIST < /tmp/elblist
+        rm -f /tmp/elblist
+    else
+        error_exit "Must have at least one load balancer to register to"
+    fi
 fi
 
 # Loop through all LBs the user set, and attempt to register this instance to them.


### PR DESCRIPTION
This PR removes the need to manually set `ELB_LIST` when not using an auto-balancer, and removes the step in the README.md where this is required.

In `deregister_from_elb.sh`, if `ELB_LIST` is empty this PR calls the existing `get_elb_list` function to automatically find all load balancers the instance is currently registered to, then writes this list to a temp file (`/tmp/elblist`).

In `register_with_elb.sh`, if `ELB_LIST` is empty this PR reads the list of previously-registered load balancers from the temp file (`/tmp/elblist`).

The behavior is unchanged when an auto-scaling group is used.