### PR TITLE
Suspend ASG processes while deploying

### DIFF
--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -9,6 +9,8 @@ your instances are a part of, set the scripts in the appropriate lifecycle event
 will take care of deregistering the instance, waiting for connection draining, and re-registering
 after the deployment finishes.
 
+*Please note that this scripts will suspend some AutoScaling processes (AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy) while deploying, in order to avoid wrong interactions.*
+
 ## Requirements
 
 The register and deregister scripts have a couple of dependencies in order to properly interact with
@@ -19,36 +21,33 @@ AutoScaling's Standby feature, the CLI must be at least version 1.3.25. If you
 have Python and PIP already installed, the CLI can simply be installed with `pip
 install awscli`. Otherwise, follow the [installation instructions](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 in the CLI's user guide.
-1. An instance profile with a policy that allows, at minimum, the following actions:
+2. An instance profile with a policy that allows, at minimum, the following actions:
 
-```
-    elasticloadbalancing:Describe*
-    elasticloadbalancing:DeregisterInstancesFromLoadBalancer
-    elasticloadbalancing:RegisterInstancesWithLoadBalancer
-    autoscaling:Describe*
-    autoscaling:EnterStandby
-    autoscaling:ExitStandby
-    autoscaling:UpdateAutoScalingGroup
-    autoscaling:SuspendProcesses
-    autoscaling:ResumeProcesses
-```
+        elasticloadbalancing:Describe*
+        elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+        elasticloadbalancing:RegisterInstancesWithLoadBalancer
+        autoscaling:Describe*
+        autoscaling:EnterStandby
+        autoscaling:ExitStandby
+        autoscaling:UpdateAutoScalingGroup
+        autoscaling:SuspendProcesses
+        autoscaling:ResumeProcesses
 
-Note: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that
-are to participate in AWS CodeDeploy deployments. For more information on creating an instance
-profile for AWS CodeDeploy, see the [Create an IAM Instance Profile for Your Amazon EC2 Instances]()
-topic in the documentation.
-1. All instances are assumed to already have the AWS CodeDeploy Agent installed.
+    **Note**: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that
+    are to participate in AWS CodeDeploy deployments. For more information on creating an instance
+    profile for AWS CodeDeploy, see the [Create an IAM Instance Profile for Your Amazon EC2 Instances](http://docs.aws.amazon.com/codedeploy/latest/userguide/how-to-create-iam-instance-profile.html)
+    topic in the documentation.
+3. All instances are assumed to already have the AWS CodeDeploy Agent installed.
 
 ## Installing the Scripts
 
 To use these scripts in your own application:
 
 1. Install the AWS CLI on all your instances.
-1. Update the policies on the EC2 instance profile to allow the above actions.
-1. Copy the `.sh` files in this directory into your application source.
-1. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
+2. Update the policies on the EC2 instance profile to allow the above actions.
+3. Copy the `.sh` files in this directory into your application source.
+4. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
 and `register_with_elb.sh` on the ApplicationStart event.
-1. Edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load
+5. Edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load
 Balancer(s) your deployment group is a part of. Make sure the entries in ELB_LIST are separated by space.
-1. Deploy!
-
+6. Deploy!

--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -29,6 +29,8 @@ in the CLI's user guide.
     autoscaling:EnterStandby
     autoscaling:ExitStandby
     autoscaling:UpdateAutoScalingGroup
+    autoscaling:SuspendProcesses
+    autoscaling:ResumeProcesses
 ```
 
 Note: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -94,11 +94,15 @@ check_suspended_processes() {
       --query 'AutoScalingGroups[].SuspendedProcesses' \
       --output text | awk '{printf $1" "}'))
 
-  msg "This processes were suspended on the ASG before starting ${suspended[*]}"
+  if [ ${#suspended[@]} -eq 0 ]; then
+    msg "No processes were suspended on the ASG before starting."
+  else
+    msg "This processes were suspended on the ASG before starting: ${suspended[*]}"
+  fi
 
   # If "Launch" process is suspended abort because we will not be able to recover from StandBy
   if [[ "${suspended[@]}" =~ "Launch" ]]; then
-    error_exit "Launch process of AutoScaling is suspended which will not allow us to recover the instance from StandBy. Aborting."
+    error_exit "'Launch' process of AutoScaling is suspended which will not allow us to recover the instance from StandBy. Aborting."
   fi
 
   for process in ${suspended[@]}; do

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -93,6 +93,18 @@ remove_flagfile() {
   fi
 }
 
+# Usage: finish_msg
+#
+#   Prints some finishing statistics
+finish_msg() {
+  msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
+  
+  end_sec=$(/bin/date +%s.%N)
+  elapsed_seconds=$(echo "$end_sec - $start_sec" | /usr/bin/bc)
+  
+  msg "Elapsed time: $elapsed_seconds"
+}
+
 # Usage: autoscaling_group_name <EC2 instance ID>
 #
 #    Prints to STDOUT the name of the AutoScaling group this instance is a part of and returns 0. If

--- a/load-balancing/elb/deregister_from_elb.sh
+++ b/load-balancing/elb/deregister_from_elb.sh
@@ -44,6 +44,7 @@ if [ $? == 0 -a -n "${asg}" ]; then
         error_exit "Failed to move instance into standby"
     else
         msg "Instance is in standby"
+        finish_msg
         exit 0
     fi
 fi
@@ -81,9 +82,4 @@ for elb in $ELB_LIST; do
     fi
 done
 
-msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
-
-end_sec=$(/bin/date +%s.%N)
-elapsed_seconds=$(echo "$end_sec - $start_sec" | /usr/bin/bc)
-
-msg "Elapsed time: $elapsed_seconds"
+finish_msg

--- a/load-balancing/elb/register_with_elb.sh
+++ b/load-balancing/elb/register_with_elb.sh
@@ -44,6 +44,7 @@ if [ $? == 0 -a -n "${asg}" ]; then
         error_exit "Failed to move instance out of standby"
     else
         msg "Instance is no longer in Standby"
+        finish_msg
         exit 0
     fi
 fi
@@ -81,9 +82,4 @@ for elb in $ELB_LIST; do
     fi
 done
 
-msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
-
-end_sec=$(/bin/date +%s.%N)
-elapsed_seconds=$(echo "$end_sec - $start_sec" | /usr/bin/bc)
-
-msg "Elapsed time: $elapsed_seconds"
+finish_msg


### PR DESCRIPTION
With this patch the _AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy_ processes on the AutoScaling Group are suspended while doing the deployment.

This is needed because if a scale up/down, a rebalance or any other activity modifies the instances of the ASG it will cause a failed deployment.

This is a more general approach than the PR #37, which I'll be closing after submitting this one.

The state of previously suspended processes in the ASG is preserved. I.e. if AZRebalanced was configured by the user to be suspended previous to the deployment it will still be suspended after it's done.

Scripts will exit with an error if any of the suspension/resuming API calls fail.

**In detail:**
- Implemented some functions to handle the state of the processes through a flag file. [_This is needed because register and deregister scripts are called at different lifecycle events and environment is not shared as they are invoked by the CodeDeploy agent._]
- Unified the flag file of _"decremented ASG group"_ into the same file so that we only use one file.
- Made the flag file have the Deployment Group ID and Deployment ID in it's filename in case potential issues need to be tracked.
- Updated the README.md file with a notice about the new behaviour and the needed policies on IAM.