### PR TITLE
Improvements for ELB functionality

### DIFF
--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -1,26 +1,15 @@
 # ELB and ASG lifecycle event scripts
 
-Often when running a web service, you'll have your instances behind a load balancer. But when
-deploying new code to these instances, you don't want the load balancer to continue sending customer
-traffic to an instance while the deployment is in progress. Lifecycle event scripts give you the
-ability to integrate your AWS CodeDeploy deployments with instances that are behind an Elastic Load
-Balancer or in an Auto Scaling group. Simply set the name (or names) of the Elastic Load Balancer
-your instances are a part of, set the scripts in the appropriate lifecycle events, and the scripts
-will take care of deregistering the instance, waiting for connection draining, and re-registering
-after the deployment finishes.
+Often when running a web service, you'll have your instances behind a load balancer. But when deploying new code to these instances, you don't want the load balancer to continue sending customer traffic to an instance while the deployment is in progress. Lifecycle event scripts give you the ability to integrate your AWS CodeDeploy deployments with instances that are behind an Elastic Load Balancer or in an Auto Scaling group. Simply set the name (or names) of the Elastic Load Balancer your instances are a part of, set the scripts in the appropriate lifecycle events, and the scripts will take care of deregistering the instance, waiting for connection draining, and re-registering after the deployment finishes.
 
 *Please note that this scripts will suspend some AutoScaling processes (AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy) while deploying, in order to avoid wrong interactions.*
 
 ## Requirements
 
-The register and deregister scripts have a couple of dependencies in order to properly interact with
-Elastic Load Balancing and AutoScaling:
+The register and deregister scripts have a couple of dependencies in order to properly interact with Elastic Load Balancing and AutoScaling:
 
-1. The [AWS CLI](http://aws.amazon.com/cli/). In order to take advantage of
-AutoScaling's Standby feature, the CLI must be at least version 1.3.25. If you
-have Python and PIP already installed, the CLI can simply be installed with `pip
-install awscli`. Otherwise, follow the [installation instructions](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
-in the CLI's user guide.
+1. The [AWS CLI](http://aws.amazon.com/cli/). In order to take advantage of AutoScaling's Standby feature, the CLI must be at least version 1.3.25. If you have Python and PIP already installed, the CLI can simply be installed with `pip install awscli`. Otherwise, follow the [installation instructions](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) in the CLI's user guide.
+
 2. An instance profile with a policy that allows, at minimum, the following actions:
 
         elasticloadbalancing:Describe*
@@ -33,10 +22,8 @@ in the CLI's user guide.
         autoscaling:SuspendProcesses
         autoscaling:ResumeProcesses
 
-    **Note**: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that
-    are to participate in AWS CodeDeploy deployments. For more information on creating an instance
-    profile for AWS CodeDeploy, see the [Create an IAM Instance Profile for Your Amazon EC2 Instances](http://docs.aws.amazon.com/codedeploy/latest/userguide/how-to-create-iam-instance-profile.html)
-    topic in the documentation.
+    **Note**: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that are to participate in AWS CodeDeploy deployments. For more information on creating an instance profile for AWS CodeDeploy, see the [Create an IAM Instance Profile for Your Amazon EC2 Instances](http://docs.aws.amazon.com/codedeploy/latest/userguide/how-to-create-iam-instance-profile.html) topic in the documentation.
+
 3. All instances are assumed to already have the AWS CodeDeploy Agent installed.
 
 ## Installing the Scripts
@@ -46,8 +33,7 @@ To use these scripts in your own application:
 1. Install the AWS CLI on all your instances.
 2. Update the policies on the EC2 instance profile to allow the above actions.
 3. Copy the `.sh` files in this directory into your application source.
-4. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
-and `register_with_elb.sh` on the ApplicationStart event.
-5. Edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load
-Balancer(s) your deployment group is a part of. Make sure the entries in ELB_LIST are separated by space.
+4. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event, and `register_with_elb.sh` on the ApplicationStart event.
+5. If your instance is not in an Auto Scaling Group, edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load Balancer(s) your deployment group is a part of. Make sure the entries in ELB_LIST are separated by space.
+Alternatively, you can set `ELB_LIST` to `_all_` to automatically use all load balancers the instance is registered to, or `_any_` to get the same behaviour as `_all_` but without failing your deployments if the instance is not part of any ASG or ELB. This is more flexible in heterogeneous tag-based Deployment Groups.
 6. Deploy!

--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -9,6 +9,8 @@ your instances are a part of, set the scripts in the appropriate lifecycle event
 will take care of deregistering the instance, waiting for connection draining, and re-registering
 after the deployment finishes.
 
+*Please note that this scripts will suspend some AutoScaling processes (AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy) while deploying, in order to avoid wrong interactions.*
+
 ## Requirements
 
 The register and deregister scripts have a couple of dependencies in order to properly interact with
@@ -19,36 +21,33 @@ AutoScaling's Standby feature, the CLI must be at least version 1.3.25. If you
 have Python and PIP already installed, the CLI can simply be installed with `pip
 install awscli`. Otherwise, follow the [installation instructions](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 in the CLI's user guide.
-1. An instance profile with a policy that allows, at minimum, the following actions:
+2. An instance profile with a policy that allows, at minimum, the following actions:
 
-```
-    elasticloadbalancing:Describe*
-    elasticloadbalancing:DeregisterInstancesFromLoadBalancer
-    elasticloadbalancing:RegisterInstancesWithLoadBalancer
-    autoscaling:Describe*
-    autoscaling:EnterStandby
-    autoscaling:ExitStandby
-    autoscaling:UpdateAutoScalingGroup
-    autoscaling:SuspendProcesses
-    autoscaling:ResumeProcesses
-```
+        elasticloadbalancing:Describe*
+        elasticloadbalancing:DeregisterInstancesFromLoadBalancer
+        elasticloadbalancing:RegisterInstancesWithLoadBalancer
+        autoscaling:Describe*
+        autoscaling:EnterStandby
+        autoscaling:ExitStandby
+        autoscaling:UpdateAutoScalingGroup
+        autoscaling:SuspendProcesses
+        autoscaling:ResumeProcesses
 
-Note: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that
-are to participate in AWS CodeDeploy deployments. For more information on creating an instance
-profile for AWS CodeDeploy, see the [Create an IAM Instance Profile for Your Amazon EC2 Instances]()
-topic in the documentation.
-1. All instances are assumed to already have the AWS CodeDeploy Agent installed.
+    **Note**: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that
+    are to participate in AWS CodeDeploy deployments. For more information on creating an instance
+    profile for AWS CodeDeploy, see the [Create an IAM Instance Profile for Your Amazon EC2 Instances](http://docs.aws.amazon.com/codedeploy/latest/userguide/how-to-create-iam-instance-profile.html)
+    topic in the documentation.
+3. All instances are assumed to already have the AWS CodeDeploy Agent installed.
 
 ## Installing the Scripts
 
 To use these scripts in your own application:
 
 1. Install the AWS CLI on all your instances.
-1. Update the policies on the EC2 instance profile to allow the above actions.
-1. Copy the `.sh` files in this directory into your application source.
-1. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
+2. Update the policies on the EC2 instance profile to allow the above actions.
+3. Copy the `.sh` files in this directory into your application source.
+4. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
 and `register_with_elb.sh` on the ApplicationStart event.
-1. Edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load
+5. Edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load
 Balancer(s) your deployment group is a part of. Make sure the entries in ELB_LIST are separated by space.
-1. Deploy!
-
+6. Deploy!

--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -2,8 +2,6 @@
 
 Often when running a web service, you'll have your instances behind a load balancer. But when deploying new code to these instances, you don't want the load balancer to continue sending customer traffic to an instance while the deployment is in progress. Lifecycle event scripts give you the ability to integrate your AWS CodeDeploy deployments with instances that are behind an Elastic Load Balancer or in an Auto Scaling group. Simply set the name (or names) of the Elastic Load Balancer your instances are a part of, set the scripts in the appropriate lifecycle events, and the scripts will take care of deregistering the instance, waiting for connection draining, and re-registering after the deployment finishes.
 
-*Please note that this scripts will suspend some AutoScaling processes (AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy) while deploying, in order to avoid wrong interactions.*
-
 ## Requirements
 
 The register and deregister scripts have a couple of dependencies in order to properly interact with Elastic Load Balancing and AutoScaling:
@@ -36,4 +34,20 @@ To use these scripts in your own application:
 4. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event, and `register_with_elb.sh` on the ApplicationStart event.
 5. If your instance is not in an Auto Scaling Group, edit `common_functions.sh` to set `ELB_LIST` to contain the name(s) of the Elastic Load Balancer(s) your deployment group is a part of. Make sure the entries in ELB_LIST are separated by space.
 Alternatively, you can set `ELB_LIST` to `_all_` to automatically use all load balancers the instance is registered to, or `_any_` to get the same behaviour as `_all_` but without failing your deployments if the instance is not part of any ASG or ELB. This is more flexible in heterogeneous tag-based Deployment Groups.
-6. Deploy!
+6. Optionally set up `HANDLE_PROCS=true` in `common_functions.sh`. See note below.
+7. Deploy!
+
+## Important notice about handling AutoScaling processes
+
+When using AutoScaling with CodeDeploy you have to consider some edge cases during the deployment time window:
+
+1. If you have a scale up event, the new instance(s) will get the latest successful *Revision*, and not the one you are currently deploying. You will end up with a fleet of mixed revisions.
+2. If you have a scale down event, instances are going to be terminated, and your deployment will (probably) fail.
+3. If your instances are not balanced accross Availability Zones **and you are** using these scripts, AutoScaling may terminate some instances or create new ones to maintain balance (see [this doc](http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html#process-types)), interfering with your deployment.
+4. If you have the health checks of your AutoScaling Group based off the ELB's ([documentation](http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html)) **and you are not** using these scripts, then instances will be marked as unhealthy and terminated, interfering with your deployment.
+
+In an effort to solve these cases, the scripts can suspend some AutoScaling processes (AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy) while deploying, to avoid those events happening in the middle of your deployment. You only have to set up `HANDLE_PROCS=true` in `common_functions.sh`.
+
+A record of the previously (to the start of the deployment) suspended process is kept by the scripts (on each instance), so when finishing the deployment the status of the processes on the AutoScaling Group should be returned to the same status as before. I.e. if AZRebalance was suspended manually it will not be resumed. However, if the scripts don't run (failed deployment) you may end up with stale suspended processes.
+
+**WARNING**: If you are using this functionality you should only use *CodeDepoyDefault.OneAtATime* deployment configuration to ensure a serial execution of the scripts. Concurrent runs are not supported.

--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -29,6 +29,8 @@ in the CLI's user guide.
     autoscaling:EnterStandby
     autoscaling:ExitStandby
     autoscaling:UpdateAutoScalingGroup
+    autoscaling:SuspendProcesses
+    autoscaling:ResumeProcesses
 ```
 
 Note: the AWS CodeDeploy Agent requires that an instance profile be attached to all instances that

--- a/load-balancing/elb/README.md
+++ b/load-balancing/elb/README.md
@@ -50,4 +50,6 @@ In an effort to solve these cases, the scripts can suspend some AutoScaling proc
 
 A record of the previously (to the start of the deployment) suspended process is kept by the scripts (on each instance), so when finishing the deployment the status of the processes on the AutoScaling Group should be returned to the same status as before. I.e. if AZRebalance was suspended manually it will not be resumed. However, if the scripts don't run (failed deployment) you may end up with stale suspended processes.
 
+Disclaimer: There's a small chance that an event is triggered while the deployment is progressing from one instance to another. The only way to avoid that completely whould be to monitor the deployment externally to CodeDeploy/AutoScaling and act accordingly. The effort on doing that compared to this depends on the each use case.
+
 **WARNING**: If you are using this functionality you should only use *CodeDepoyDefault.OneAtATime* deployment configuration to ensure a serial execution of the scripts. Concurrent runs are not supported.

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -94,11 +94,15 @@ check_suspended_processes() {
       --query 'AutoScalingGroups[].SuspendedProcesses' \
       --output text | awk '{printf $1" "}'))
 
-  msg "This processes were suspended on the ASG before starting ${suspended[*]}"
+  if [ ${#suspended[@]} -eq 0 ]; then
+    msg "No processes were suspended on the ASG before starting."
+  else
+    msg "This processes were suspended on the ASG before starting: ${suspended[*]}"
+  fi
 
   # If "Launch" process is suspended abort because we will not be able to recover from StandBy
   if [[ "${suspended[@]}" =~ "Launch" ]]; then
-    error_exit "Launch process of AutoScaling is suspended which will not allow us to recover the instance from StandBy. Aborting."
+    error_exit "'Launch' process of AutoScaling is suspended which will not allow us to recover the instance from StandBy. Aborting."
   fi
 
   for process in ${suspended[@]}; do

--- a/load-balancing/elb/common_functions.sh
+++ b/load-balancing/elb/common_functions.sh
@@ -93,6 +93,18 @@ remove_flagfile() {
   fi
 }
 
+# Usage: finish_msg
+#
+#   Prints some finishing statistics
+finish_msg() {
+  msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
+  
+  end_sec=$(/bin/date +%s.%N)
+  elapsed_seconds=$(echo "$end_sec - $start_sec" | /usr/bin/bc)
+  
+  msg "Elapsed time: $elapsed_seconds"
+}
+
 # Usage: autoscaling_group_name <EC2 instance ID>
 #
 #    Prints to STDOUT the name of the AutoScaling group this instance is a part of and returns 0. If

--- a/load-balancing/elb/deregister_from_elb.sh
+++ b/load-balancing/elb/deregister_from_elb.sh
@@ -44,6 +44,7 @@ if [ $? == 0 -a -n "${asg}" ]; then
         error_exit "Failed to move instance into standby"
     else
         msg "Instance is in standby"
+        finish_msg
         exit 0
     fi
 fi
@@ -81,9 +82,4 @@ for elb in $ELB_LIST; do
     fi
 done
 
-msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
-
-end_sec=$(/bin/date +%s.%N)
-elapsed_seconds=$(echo "$end_sec - $start_sec" | /usr/bin/bc)
-
-msg "Elapsed time: $elapsed_seconds"
+finish_msg

--- a/load-balancing/elb/deregister_from_elb.sh
+++ b/load-balancing/elb/deregister_from_elb.sh
@@ -51,6 +51,8 @@ fi
 
 msg "Instance is not part of an ASG, trying with ELB..."
 
+set_flag "dereg" "true"
+
 if [ -z "$ELB_LIST" ]; then
     error_exit "ELB_LIST is empty. Must have at least one load balancer to deregister from, or \"_all_\", \"_any_\" values."
 elif [ "${ELB_LIST}" = "_all_" ]; then

--- a/load-balancing/elb/register_with_elb.sh
+++ b/load-balancing/elb/register_with_elb.sh
@@ -54,19 +54,31 @@ msg "Instance is not part of an ASG, continuing with ELB"
 if [ -z "$ELB_LIST" ]; then
     error_exit "ELB_LIST is empty. Must have at least one load balancer to register to, or \"_all_\", \"_any_\" values."
 elif [ "${ELB_LIST}" = "_all_" ]; then
-    msg "Finding all the ELBs that this instance was previously registered to"
-    if ! ELB_LIST=$(get_flag "ELBs"); then
-      error_exit "$FLAGFILE doesn't exist or is unreadble"
-    elif [ -z $ELB_LIST ]; then
-      error_exit "Couldn't find any. Must have at least one load balancer to register to."
+    if [ "$(get_flag "dereg")" = "true" ]; then
+        msg "Finding all the ELBs that this instance was previously registered to"
+        if ! ELB_LIST=$(get_flag "ELBs"); then
+          error_exit "$FLAGFILE doesn't exist or is unreadble"
+        elif [ -z $ELB_LIST ]; then
+          error_exit "Couldn't find any. Must have at least one load balancer to register to."
+        fi
+    else
+        msg "Assuming this is the first deployment and ELB_LIST=_all_ so finishing successfully without registering."
+        finish_msg
+        exit 0
     fi
 elif [ "${ELB_LIST}" = "_any_" ]; then
-    msg "Finding all the ELBs that this instance was previously registered to"
-    if ! ELB_LIST=$(get_flag "ELBs"); then
-      error_exit "$FLAGFILE doesn't exist or is unreadble"
-    elif [ -z $ELB_LIST ]; then
-        msg "Couldn't find any, but ELB_LIST=any so finishing successfully without registering."
-        remove_flagfile
+    if [ "$(get_flag "dereg")" = "true" ]; then
+        msg "Finding all the ELBs that this instance was previously registered to"
+        if ! ELB_LIST=$(get_flag "ELBs"); then
+            error_exit "$FLAGFILE doesn't exist or is unreadble"
+        elif [ -z $ELB_LIST ]; then
+            msg "Couldn't find any, but ELB_LIST=_any_ so finishing successfully without registering."
+            remove_flagfile
+            finish_msg
+            exit 0
+        fi
+    else
+        msg "Assuming this is the first deployment and ELB_LIST=_any_ so finishing successfully without registering."
         finish_msg
         exit 0
     fi

--- a/load-balancing/elb/register_with_elb.sh
+++ b/load-balancing/elb/register_with_elb.sh
@@ -44,6 +44,7 @@ if [ $? == 0 -a -n "${asg}" ]; then
         error_exit "Failed to move instance out of standby"
     else
         msg "Instance is no longer in Standby"
+        finish_msg
         exit 0
     fi
 fi
@@ -81,9 +82,4 @@ for elb in $ELB_LIST; do
     fi
 done
 
-msg "Finished $(basename $0) at $(/bin/date "+%F %T")"
-
-end_sec=$(/bin/date +%s.%N)
-elapsed_seconds=$(echo "$end_sec - $start_sec" | /usr/bin/bc)
-
-msg "Elapsed time: $elapsed_seconds"
+finish_msg


### PR DESCRIPTION
After reviewing PRs #40 and #41 from @wjordan I realized that my PR #43 was only fixing issues with ASGs.

I integrated those changes (with some extra tweaks) into this new PR, which is based off a branch of my _asg_suspend_processes_. So you can consider this superseding all those previous PRs. Adding my previous comments below quoted, for reference.

This are the added changes:

- Updated README.md with info about ELB_LIST options of `_all_` and `_any_` as well as a style fix.
- Improved set_flag/get_flag functions to support storing/getting arbitrary values.
- Removed dependency on `bc` by using `awk` instead.
- Removed ASG checks from `reset_waiter_timeout` as it's only considered for ELBs.
- Further improved the query string on `reset_waiter_timeout` function (and tested it working on Ubuntu Trusty)

> With this patch the _AZRebalance, AlarmNotification, ScheduledActions and ReplaceUnhealthy_ processes on the AutoScaling Group are suspended while doing the deployment.

>This is needed because if a scale up/down, a rebalance or any other activity modifies the instances of the ASG it will cause a failed deployment.

>This is a more general approach than the PR #37, which I'll be closing after submitting this one.

>The state of previously suspended processes in the ASG is preserved. I.e. if AZRebalanced was configured by the user to be suspended previous to the deployment it will still be suspended after it's done.

>Scripts will exit with an error if any of the suspension/resuming API calls fail.

>**In detail:**
- Implemented some functions to handle the state of the processes through a flag file. [_This is needed because register and deregister scripts are called at different lifecycle events and environment is not shared as they are invoked by the CodeDeploy agent._]
- Unified the flag file of _"decremented ASG group"_ into the same file so that we only use one file.
- Made the flag file have the Deployment Group ID and Deployment ID in it's filename in case potential issues need to be tracked.
- Updated the README.md file with a notice about the new behaviour and the needed policies on IAM.