### PR TITLE
remove "not a valid identifier" for bash

### DIFF
--- a/load-balancing/elb-v2/common_functions.sh
+++ b/load-balancing/elb-v2/common_functions.sh
@@ -316,10 +316,10 @@ wait_for_state() {
         if [ $? != 0 ]; then
             error_exit "Failed re-setting waiter timeout for $target_group"
         fi
-        local waiter_interval = $WAITER_INTERVAL_ALB
+        local waiter_interval=$WAITER_INTERVAL_ALB
     elif [ "$service" == "autoscaling" ]; then
         instance_state_cmd="get_instance_state_asg $instance_id"
-        local waiter_interval = $WAITER_INTERVAL_ASG
+        local waiter_interval=$WAITER_INTERVAL_ASG
     else
         msg "Cannot wait for instance state; unknown service type, '$service'"
         return 1


### PR DESCRIPTION
refs. #49 

```
2016-08-15 22:13:19 [stderr]/opt/codedeploy-agent/deployment-root/c86ed025-5edf-4da5-86bc-bc7e2c6b285b/d-IFJQ8CQYG/deployment-archive/scripts/common_functions.sh: line 322: local: `=': not a valid identifier
2016-08-15 22:13:19 [stderr]/opt/codedeploy-agent/deployment-root/c86ed025-5edf-4da5-86bc-bc7e2c6b285b/d-IFJQ8CQYG/deployment-archive/scripts/common_functions.sh: line 322: local: `1': not a valid identifier
```

remove spaces at both sides of `=` .