### PR TITLE
fix bug: local variable waiter_interval definition

### DIFF
--- a/load-balancing/elb-v2/common_functions.sh
+++ b/load-balancing/elb-v2/common_functions.sh
@@ -316,10 +316,10 @@ wait_for_state() {
         if [ $? != 0 ]; then
             error_exit "Failed re-setting waiter timeout for $target_group"
         fi
-        local waiter_interval = $WAITER_INTERVAL_ALB
+        local waiter_interval=$WAITER_INTERVAL_ALB
     elif [ "$service" == "autoscaling" ]; then
         instance_state_cmd="get_instance_state_asg $instance_id"
-        local waiter_interval = $WAITER_INTERVAL_ASG
+        local waiter_interval=$WAITER_INTERVAL_ASG
     else
         msg "Cannot wait for instance state; unknown service type, '$service'"
         return 1


### PR DESCRIPTION
fix bug: local variable waiter_interval definition in `load-balancing/elb-v2/common_functions.sh`.

It will getting erroor below:
```
load-balancing/elb-v2/common_functions.sh: line 319: local: `=': not a valid identifier
load-balancing/elb-v2/common_functions.sh: line 319: local: `10': not a valid identifier
```