### PR TITLE
Brings consistency to the TARGET_GROUP_LIST variable

### DIFF
--- a/load-balancing/elb-v2/README.md
+++ b/load-balancing/elb-v2/README.md
@@ -46,6 +46,6 @@ To use these scripts in your own application:
 1. Copy the `.sh` files in this directory into your application source.
 1. Edit your application's `appspec.yml` to run `deregister_from_elb.sh` on the ApplicationStop event,
 and `register_with_elb.sh` on the ApplicationStart event.
-1. Edit `common_functions.sh` to set `TARGET_LIST` to contain the name(s) of the Target Group your deployment group is a part of. Make sure the entries in TARGET_LIST are separated by space.
+1. Edit `common_functions.sh` to set `TARGET_GROUP_LIST` to contain the name(s) of the Target Group your deployment group is a part of. Make sure the entries in `TARGET_GROUP_LIST` are separated by space.
 1. Edit `common_functions.sh` to set `PORT` to the port number your application is running at (if it's different from the default port number set in Target Group)
 1. Deploy!

--- a/load-balancing/elb-v2/common_functions.sh
+++ b/load-balancing/elb-v2/common_functions.sh
@@ -13,8 +13,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# TARGET_LIST defines which target groups behind Load Balancer this instance should be part of.
-# The elements in TARGET_LIST should be seperated by space.
+# TARGET_GROUP_LIST defines which target groups behind Load Balancer this instance should be part of.
+# The elements in TARGET_GROUP_LIST should be seperated by space.
 TARGET_GROUP_LIST=""
 
 # PORT defines which port the application is running at.


### PR DESCRIPTION
There are a few places in the comments and the README that refer to the
variable "TARGET_LIST" in the common_functions.sh file, but the actual
variable name is "TARGET_GROUP_LIST". This commit updates the README and
comments to use "TARGET_GROUP_LIST"